### PR TITLE
Rewrite some parts of the code to fix syntax error

### DIFF
--- a/pintaboard.js
+++ b/pintaboard.js
@@ -139,13 +139,12 @@ function pinStoredTagData(ctx){
 
 
 function pinCompleteBookmark(context, args){
-    if(!args.bang){
-	context.title = ["Page URL"];
-	let frames = buffer.allFrames();
-	context.completions = [
-	    [win.document.documentURI, frames.length == 1 ? "Current Location" : "Frame: " + win.document.title]
-	    for ([, win] in Iterator(frames))];
-	return;
+    if (!args.bang) {
+        context.title = ["Page URL"];
+        let frames = buffer.allFrames();
+        context.completions = frames.map(win => [win.document.documentURI,
+                                                 frames.length == 1 ? /*L*/"Current Location"
+                                                                    : /*L*/"Frame: " + win.document.title]);
     }
 }
 
@@ -224,9 +223,9 @@ function initPintaboard() {
 	description: "Bookmark page title",
 	completer: function description(context, args){
 	    let frames = buffer.allFrames();
-	    return [
-		[win.document.title, frames.length ==1 ? "Current Location" : "Frame: " + win.location.href]
-		for([, win] in Iterator(frames))];
+        return frames.map(win => [win.document.title,
+                                  frames.length == 1 ? /*L*/"Current Location"
+                                                     : /*L*/"Frame: " + win.location.href]);
 	},
 	type: CommandOption.STRING
     };


### PR DESCRIPTION
In newer versions of pentadactyl the code gives a syntax error. I copied
part  of  the  bookmarking  code  from  pentadactyl  to  substitute  the
failing code.

This fixes (for me) issue #8 

I want to stress that I don't know javascript and I just improvised this solution.
